### PR TITLE
Fix table getting added as `["workspace.dependencies"]`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn edit_workspace_dependency_table(
             }
         }
 
-        document.insert("workspace.dependencies", Item::Table(new_table));
+        document["workspace"]["dependencies"] = Item::Table(new_table);
     }
 }
 


### PR DESCRIPTION
`toml_edit` assumes the key needs to be taken literally here, and escapes the period (`.`) by inserting quotes (`"`) around the entire key, while `dependencies` is instead a subtable of `workspace`.

It is curious that `get_mut()` on such a key _seems_ to work, though.
