### PR TITLE
ci: Disallow clippy warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         name: Clippy lint
         with:
           command: clippy
-          args: --workspace --all-targets --all-features
+          args: --workspace --all-targets --all-features -- -D warnings
 
   docs:
     name: Build-test docs


### PR DESCRIPTION
Running `clippy` is otherwise only useful to find compile-breaking issues and severe linter errors, but not warnings.
