### PR TITLE
Skip local dependencies with `path =` source

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ fn main() {
 
             for package in metadata.workspace_packages() {
                 for package_dependency in &package.dependencies {
+                    // Skip local dependencies, typically pointing to other crates in the tree
+                    if package_dependency.path.is_some() {
+                        continue;
+                    }
+
                     let mut detected_dependency = duplicated_dependencies
                         .entry(&package_dependency.name)
                         .or_insert(Entry::default());


### PR DESCRIPTION
These dependencies are typically part of a workspace and referred to with a `path = "../some/crate"` designator.  Pointing to them through a workspace dependency [is possible] and maybe even more concise at the detriment of specifying them more often, but at least without removing `path=` from the per-crate dependencies causes havoc:

    Dependency 'foo' has different source paths depending on the build target. Each dependency must have a single canonical source path irrespective of build target.

[is possible]: https://github.com/MarijnS95/cargo-dependency-inheritor/compare/move-path-to-workspace
