### PR TITLE
Move dependencies with `path =` to workspace as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "clap",
+ "dunce",
  "toml_edit",
 ]
 
@@ -121,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,9 +193,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ categories = ["command-line-utilities", "cargo"]
 [dependencies]
 cargo_metadata = "0.15.0"
 clap = { version="3.2.22", features=["derive"] }
+dunce = "1"
 toml_edit = {  version = "0.14.4", default-features = true }


### PR DESCRIPTION
Prototyping if this is a useful solution.  Still need to remove `version = "*"` if the user didn't set any.
