### PR TITLE
Omit version field if its value is `"*"`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -263,10 +263,11 @@ struct Entry {
 impl Entry {
     fn to_toml(&self) -> Item {
         let version = Value::String(Formatted::new(self.version.clone()));
-
         Item::Value(if self.no_default_features || self.path.is_some() {
             let mut itable = InlineTable::new();
-            itable.insert("version", version);
+            if self.version != "*" {
+                itable.insert("version", version);
+            }
             if let Some(path) = &self.path {
                 itable.insert("path", Value::from(path.to_str().unwrap()));
             }


### PR DESCRIPTION
Both `git` and local `path` dependencies are implicitly accepting any version as represented by `cargo_metadata`'s `version = "*"`, but emitting these results in unnecessary noise.

This change only adapts the version in inline tables as `git` translation (the common source for a `some-git-repo = "*"` in `[workspace.dependencies]`) has not yet been implemented.
