### PR TITLE
Rewrite non-inline `Table`s to use workspaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,8 +156,10 @@ fn main() {
 
                         match val {
                             Item::None => todo!(),
-                            Item::Table(_) => {
-                                // TODO
+                            Item::Table(table) => {
+                                table.insert("workspace", Item::Value(Value::from(true)));
+                                table.remove("version");
+                                table.remove("path");
                             }
                             Item::ArrayOfTables(_) => todo!(),
                             Item::Value(val) => match val {


### PR DESCRIPTION
Depends on #20

This turned out to be super trivial by just copying the implementation for `InlineTable` `Value`s... But it might be nicer to use `get_key_value_mut()` to replace/rename the `version` or `path` with `workspace = true` instead of appending it at the end.
