### PR TITLE
Apply workspace dep replacement to *all* crates when reaching `number`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,8 +156,10 @@ fn main() {
 
                         match val {
                             Item::None => todo!(),
-                            Item::Table(_) => {
-                                // TODO
+                            Item::Table(table) => {
+                                table.insert("workspace", Item::Value(Value::from(true)));
+                                table.remove("version");
+                                table.remove("path");
                             }
                             Item::ArrayOfTables(_) => todo!(),
                             Item::Value(val) => match val {


### PR DESCRIPTION
Depends on #21

Currently workspace members only get added to `workspace_packages` once there have been `number` of members before it with the same dependency, meaning that all those before it have **NOT** been added to the list (give or take reaching `number` on _another_ dependency), leading to some `Cargo.toml` files being skipped even though one or more of their dependencies were added to `[workspace.dependencies]`.

For example, running on our codebase with `--number 20` leads to about 17 crates not having `glam = "someversion"` replaced with `glam = { workspace = true }`!
